### PR TITLE
Remove instances of undefined and only test truthiness in compact()

### DIFF
--- a/dist/lists/compact.scss
+++ b/dist/lists/compact.scss
@@ -2,7 +2,7 @@
   $compacted: ();
 
   @each $item in $list {
-    @if $item and $item != 0 and $item != undefined {
+    @if $item {
       $compacted: append($compacted, $item, comma);
     }
   }

--- a/dist/lists/first.scss
+++ b/dist/lists/first.scss
@@ -1,6 +1,6 @@
 @function first($list, $nth: 1) {
   @if length($list) == 0 {
-    @return undefined;
+    @return null;
   }
 
   $output: ();

--- a/dist/lists/initial.scss
+++ b/dist/lists/initial.scss
@@ -1,6 +1,6 @@
 @function initial($list, $nth: 1) {
   @if length($list) == 0 {
-    @return undefined;
+    @return null;
   }
 
   @if length($list) == 1 {

--- a/dist/lists/last.scss
+++ b/dist/lists/last.scss
@@ -2,7 +2,7 @@
   $length: length($list);
 
   @if $length == 0 {
-    @return undefined;
+    @return null;
   }
 
   $output: ();

--- a/dist/lists/rest.scss
+++ b/dist/lists/rest.scss
@@ -2,7 +2,7 @@
   $length: length($list);
 
   @if $length == 0 {
-    @return undefined;
+    @return null;
   }
 
   @if $length == 1 {

--- a/test/lists/compact.scss
+++ b/test/lists/compact.scss
@@ -1,9 +1,9 @@
 @include describe("Arrays::Compact") {
   @include it("should remove all falsy values from array") {
-    $list-1: 0,  1 , undefined,  2 , false,  3 , null,  4 ;
-    $list-2: 0, "a", undefined, "b", false, "c", null, "d";
+    $list-1: 0,  1 , 2 , false,  3 , null,  4 ;
+    $list-2: "a", "b", false, "c", null, "d";
 
-    @include should(expect( compact( $list-1 )), to( equal( (1, 2, 3, 4) )));
+    @include should(expect( compact( $list-1 )), to( equal( (0, 1, 2, 3, 4) )));
     @include should(expect( compact( $list-2 )), to( equal( ("a", "b", "c", "d") )));
   }
 

--- a/test/lists/first.scss
+++ b/test/lists/first.scss
@@ -53,11 +53,11 @@
     @include should(expect( take($boolean) ), to( equal( true )));
   }
 
-  @include it("should return undefined when a list is empty") {
+  @include it("should return null when a list is empty") {
     $empty: ();
 
-    @include should(expect( first($empty) ), to( be-undefined() ));
-    @include should(expect( head($empty) ), to( be-undefined() ));
-    @include should(expect( take($empty) ), to( be-undefined() ));
+    @include should(expect( first($empty) ), to( be-null() ));
+    @include should(expect( head($empty) ), to( be-null() ));
+    @include should(expect( take($empty) ), to( be-null() ));
   }
 }

--- a/test/lists/initial.scss
+++ b/test/lists/initial.scss
@@ -29,9 +29,9 @@
     @include should(expect( initial($boolean) ), to( equal( true )));
   }
 
-  @include it("should return undefined when a list is empty") {
+  @include it("should return null when a list is empty") {
     $empty: ();
 
-    @include should(expect( initial($empty) ), to( be-undefined() ));
+    @include should(expect( initial($empty) ), to( be-null() ));
   }
 }

--- a/test/lists/intersection.scss
+++ b/test/lists/intersection.scss
@@ -8,9 +8,9 @@
     $list-2b: "bar", "nan", "foo";
     $list-2c: "foo", "baz", "bar";
 
-    $list-3a:      true,  false, false;
-    $list-3b:      true,   null, false;
-    $list-3c: undefined,  false,  true;
+    $list-3a: true,  false, false;
+    $list-3b: true,   null, false;
+    $list-3c: null,  false,  true;
 
     @include should(expect( intersection($list-1a, $list-1b, $list-1c) ), to( equal( ( 1, 2 ) )));
     @include should(expect( intersection($list-2a, $list-2b, $list-2c) ), to( equal( ( "foo", "bar" ) )));

--- a/test/lists/last.scss
+++ b/test/lists/last.scss
@@ -29,9 +29,9 @@
     @include should(expect( last($boolean) ), to( equal( true )));
   }
 
-  @include it("should return undefined when a list is empty") {
+  @include it("should return null when a list is empty") {
     $empty: ();
 
-    @include should(expect( last($empty) ), to( be-undefined() ));
+    @include should(expect( last($empty) ), to( be-null() ));
   }
 }

--- a/test/lists/rest.scss
+++ b/test/lists/rest.scss
@@ -53,11 +53,11 @@
     @include should(expect( drop($boolean) ), to( equal( true )));
   }
 
-  @include it("should return undefined when a list is empty") {
+  @include it("should return null when a list is empty") {
     $empty: ();
 
-    @include should(expect( rest($empty) ), to( be-undefined() ));
-    @include should(expect( tail($empty) ), to( be-undefined() ));
-    @include should(expect( drop($empty) ), to( be-undefined() ));
+    @include should(expect( rest($empty) ), to( be-null() ));
+    @include should(expect( tail($empty) ), to( be-null() ));
+    @include should(expect( drop($empty) ), to( be-null() ));
   }
 }

--- a/test/lists/slice.scss
+++ b/test/lists/slice.scss
@@ -4,13 +4,13 @@
     $list-2: "foo", "bar", "baz", "caw", "tun";
     $list-3: true, false, true, true, false;
     $list-4: 1em, 2px, 0.2in, 1en, 7cm;
-    $list-5: null, undefined, null, null, undefined;
+    $list-5: null, false, null, null;
 
     @include should(expect( slice($list-1) ), to( deep-equal( ( 1, 2, 3, 4, 5 )                          )));
     @include should(expect( slice($list-2) ), to( deep-equal( ( "foo", "bar", "baz", "caw", "tun" )      )));
     @include should(expect( slice($list-3) ), to( deep-equal( ( true, false, true, true, false )         )));
     @include should(expect( slice($list-4) ), to( deep-equal( ( 1em, 2px, 0.2in, 1en, 7cm )              )));
-    @include should(expect( slice($list-5) ), to( deep-equal( ( null, undefined, null, null, undefined ) )));
+    @include should(expect( slice($list-5) ), to( deep-equal( ( null, false, null, null ) )));
   }
 
   @include it("should cut off the list at min") {
@@ -18,13 +18,13 @@
     $list-2: "foo", "bar", "baz", "caw", "tun";
     $list-3: true, false, true, true, false;
     $list-4: 1em, 2px, 0.2in, 1en, 7cm;
-    $list-5: null, undefined, null, null, undefined;
+    $list-5: null, false, null, null, false;
 
     @include should(expect( slice($list-1, 2) ), to( deep-equal( ( 2, 3, 4, 5 )                       )));
     @include should(expect( slice($list-2, 2) ), to( deep-equal( ( "bar", "baz", "caw", "tun" )       )));
     @include should(expect( slice($list-3, 2) ), to( deep-equal( ( false, true, true, false )         )));
     @include should(expect( slice($list-4, 2) ), to( deep-equal( ( 2px, 0.2in, 1en, 7cm )             )));
-    @include should(expect( slice($list-5, 2) ), to( deep-equal( ( undefined, null, null, undefined ) )));
+    @include should(expect( slice($list-5, 2) ), to( deep-equal( ( false, null, null, false ) )));
   }
 
   @include it("should cut off the list at negative min") {
@@ -32,13 +32,13 @@
     $list-2: "foo", "bar", "baz", "caw", "tun";
     $list-3: true, false, true, true, false;
     $list-4: 1em, 2px, 0.2in, 1en, 7cm;
-    $list-5: null, undefined, null, null, undefined;
+    $list-5: null, false, null, null, false;
 
     @include should(expect( slice($list-1, -1) ), to( deep-equal( ( 5 )         )));
     @include should(expect( slice($list-2, -1) ), to( deep-equal( ( "tun" )     )));
     @include should(expect( slice($list-3, -1) ), to( deep-equal( ( false )     )));
     @include should(expect( slice($list-4, -1) ), to( deep-equal( ( 7cm )       )));
-    @include should(expect( slice($list-5, -1) ), to( deep-equal( ( undefined ) )));
+    @include should(expect( slice($list-5, -1) ), to( deep-equal( ( false ) )));
   }
 
   @include it("should cut off the list at max") {
@@ -46,13 +46,13 @@
     $list-2: "foo", "bar", "baz", "caw", "tun";
     $list-3: true, false, true, true, false;
     $list-4: 1em, 2px, 0.2in, 1en, 7cm;
-    $list-5: null, undefined, null, null, undefined;
+    $list-5: null, false, null, null, false;
 
     @include should(expect( slice($list-1, $max: 4) ), to( deep-equal( ( 1, 2, 3, 4 )                       )));
     @include should(expect( slice($list-2, $max: 4) ), to( deep-equal( ( "foo", "bar", "baz", "caw" )       )));
     @include should(expect( slice($list-3, $max: 4) ), to( deep-equal( ( true, false, true, true )          )));
     @include should(expect( slice($list-4, $max: 4) ), to( deep-equal( ( 1em, 2px, 0.2in, 1en )             )));
-    @include should(expect( slice($list-5, $max: 4) ), to( deep-equal( ( null, undefined, null, null )      )));
+    @include should(expect( slice($list-5, $max: 4) ), to( deep-equal( ( null, false, null, null )      )));
   }
 
   @include it("should cut off the list at negative min") {
@@ -60,13 +60,13 @@
     $list-2: "foo", "bar", "baz", "caw", "tun";
     $list-3: true, false, true, true, false;
     $list-4: 1em, 2px, 0.2in, 1en, 7cm;
-    $list-5: null, undefined, null, null, undefined;
+    $list-5: null, false, null, null, false;
 
     @include should(expect( slice($list-1, $max: -1) ), to( deep-equal( ( 1, 2, 3, 4 )                  )));
     @include should(expect( slice($list-2, $max: -1) ), to( deep-equal( ( "foo", "bar", "baz", "caw" )  )));
     @include should(expect( slice($list-3, $max: -1) ), to( deep-equal( ( true, false, true, true )     )));
     @include should(expect( slice($list-4, $max: -1) ), to( deep-equal( ( 1em, 2px, 0.2in, 1en )        )));
-    @include should(expect( slice($list-5, $max: -1) ), to( deep-equal( ( null, undefined, null, null ) )));
+    @include should(expect( slice($list-5, $max: -1) ), to( deep-equal( ( null, false, null, null ) )));
   }
 
   @include it("should cut off the list at min and max") {
@@ -74,13 +74,13 @@
     $list-2: "foo", "bar", "baz", "caw", "tun";
     $list-3: true, false, true, true, false;
     $list-4: 1em, 2px, 0.2in, 1en, 7cm;
-    $list-5: null, undefined, null, null, undefined;
+    $list-5: null, false, null, null, false;
 
     @include should(expect( slice($list-1, 2, 4) ), to( deep-equal( ( 2, 3, 4 )               )));
     @include should(expect( slice($list-2, 2, 4) ), to( deep-equal( ( "bar", "baz", "caw" )   )));
     @include should(expect( slice($list-3, 2, 4) ), to( deep-equal( ( false, true, true )     )));
     @include should(expect( slice($list-4, 2, 4) ), to( deep-equal( ( 2px, 0.2in, 1en )       )));
-    @include should(expect( slice($list-5, 2, 4) ), to( deep-equal( ( undefined, null, null ) )));
+    @include should(expect( slice($list-5, 2, 4) ), to( deep-equal( ( false, null, null ) )));
   }
 
   @include it("should cut off the list at negative min and max") {
@@ -88,7 +88,7 @@
     $list-2: "foo", "bar", "baz", "caw", "tun";
     $list-3: true, false, true, true, false;
     $list-4: 1em, 2px, 0.2in, 1en, 7cm;
-    $list-5: null, undefined, null, null, undefined;
+    $list-5: null, false, null, null, false;
 
     @include should(expect( slice($list-1, -3, 4) ), to( deep-equal( ( 3, 4 )         )));
     @include should(expect( slice($list-2, -3, 4) ), to( deep-equal( ( "baz", "caw" ) )));
@@ -102,13 +102,13 @@
     $list-2: "foo", "bar", "baz", "caw", "tun";
     $list-3: true, false, true, true, false;
     $list-4: 1em, 2px, 0.2in, 1en, 7cm;
-    $list-5: null, undefined, null, null, undefined;
+    $list-5: null, false, null, null, false;
 
     @include should(expect( slice($list-1, 2, -2) ), to( deep-equal( ( 2, 3 )            )));
     @include should(expect( slice($list-2, 2, -2) ), to( deep-equal( ( "bar", "baz" )    )));
     @include should(expect( slice($list-3, 2, -2) ), to( deep-equal( ( false, true )     )));
     @include should(expect( slice($list-4, 2, -2) ), to( deep-equal( ( 2px, 0.2in )      )));
-    @include should(expect( slice($list-5, 2, -2) ), to( deep-equal( ( undefined, null ) )));
+    @include should(expect( slice($list-5, 2, -2) ), to( deep-equal( ( false, null ) )));
   }
 
   @include it("should cut off the list at negative min and negative max") {
@@ -116,7 +116,7 @@
     $list-2: "foo", "bar", "baz", "caw", "tun";
     $list-3: true, false, true, true, false;
     $list-4: 1em, 2px, 0.2in, 1en, 7cm;
-    $list-5: null, undefined, null, null, undefined;
+    $list-5: null, false, null, null, false;
 
     @include should(expect( slice($list-1, -3, -2) ), to( deep-equal( ( 3 )     )));
     @include should(expect( slice($list-2, -3, -2) ), to( deep-equal( ( "baz" ) )));

--- a/test/lists/union.scss
+++ b/test/lists/union.scss
@@ -8,13 +8,13 @@
     $list-2b: "bar", "nan", "baz";
     $list-2c: "foo", "baz", "bar";
 
-    $list-3a:      true, false, false;
-    $list-3b:      true,  null, false;
-    $list-3c: undefined,  null,  true;
+    $list-3a: true, false, false;
+    $list-3b: true,  null, false;
+    $list-3c: null,  null,  true;
 
-    @include should(expect( union($list-1a, $list-1b, $list-1c) ), to( equal( ( 1, 2, 3, 4, 6, 8             ) )));
-    @include should(expect( union($list-2a, $list-2b, $list-2c) ), to( equal( ( "foo", "bar", "baz", "nan"   ) )));
-    @include should(expect( union($list-3a, $list-3b, $list-3c) ), to( equal( ( true, false, null, undefined ) )));
+    @include should(expect( union($list-1a, $list-1b, $list-1c) ), to( equal( ( 1, 2, 3, 4, 6, 8  ) )));
+    @include should(expect( union($list-2a, $list-2b, $list-2c) ), to( equal( ( "foo", "bar", "baz", "nan" ) )));
+    @include should(expect( union($list-3a, $list-3b, $list-3c) ), to( equal( ( true, false, null ) )));
   }
 
   @include it("should return one item if all the items are the same") {
@@ -32,13 +32,13 @@
     $list-2b: "bar", ("nan", "baz");
     $list-2c: "foo", ("baz", "bar");
 
-    $list-3a:      true, (false, false);
-    $list-3b:      true, ( null, false);
-    $list-3c: undefined, ( null,  true);
+    $list-3a: true, (false, false);
+    $list-3b: true, ( null, false);
+    $list-3c: null, ( null,  true);
 
-    @include should(expect( union($list-1a, $list-1b, $list-1c) ), not-to( equal( ( 1, 2, 3, 4, 6, 8             ) )));
-    @include should(expect( union($list-2a, $list-2b, $list-2c) ), not-to( equal( ( "foo", "bar", "baz", "nan"   ) )));
-    @include should(expect( union($list-3a, $list-3b, $list-3c) ), not-to( equal( ( true, false, null, undefined ) )));
+    @include should(expect( union($list-1a, $list-1b, $list-1c) ), not-to( equal( ( 1, 2, 3, 4, 6, 8 ) )));
+    @include should(expect( union($list-2a, $list-2b, $list-2c) ), not-to( equal( ( "foo", "bar", "baz", "nan" ) )));
+    @include should(expect( union($list-3a, $list-3b, $list-3c) ), not-to( equal( ( true, false, null ) )));
   }
 
   @include it("should leave an empty array alone") {

--- a/test/lists/without.scss
+++ b/test/lists/without.scss
@@ -3,20 +3,20 @@
     $list-1: 1, 2, 3, 4, 5, 6;
     $list-2: "a", "b", "c", "b", "x";
     $list-3: true, false, true, true, false;
-    $list-4: null, undefined, null, null;
+    $list-4: null, false, null, null;
 
     @include should(expect( without($list-1, 1, 3, 6)   ), to( equal( (2, 4, 5)          )));
     @include should(expect( without($list-2, "b", "x")  ), to( equal( ("a", "c")         )));
     @include should(expect( without($list-3, true)      ), to( equal( (false, false)     )));
     @include should(expect( without($list-3, false)     ), to( equal( (true, true, true) )));
-    @include should(expect( without($list-4, undefined) ), to( equal( (null, null, null) )));
+    @include should(expect( without($list-4, false) ), to( equal( (null, null, null) )));
   }
 
   @include it("should return same list when no equaling values") {
     $list-1: 1, 2, 3, 4, 5, 6;
     $list-2: "a", "b", "c", "b", "x";
     $list-3: true, false, true, true, false;
-    $list-4: null, undefined, null, null;
+    $list-4: null, false, null, null;
 
     @include should(expect( without($list-1, green) ), to( equal( $list-1 )));
     @include should(expect( without($list-2, green) ), to( equal( $list-2 )));


### PR DESCRIPTION
#### Resolves #11
- removes all instances of `undefined` (not a thing)
- only tests truthiness in `compact()`
