### PR TITLE
Upgrade Bootcamp

### DIFF
--- a/dist/lists/intersection.scss
+++ b/dist/lists/intersection.scss
@@ -1,17 +1,27 @@
-@function intersection($list, $others...) {
-  $filtered: $list;
+@function intersection($array, $others...) {
+  $unique: ();
 
-  @each $list in $others {
-    $temp: ();
+  @each $item in $array {
+    @if not index($unique, $item) {
+      $unique: append($unique, $item, comma);
+    }
+  }
 
-    @each $item in $filtered {
-      @if not not index($list, $item) {
-        $temp: append($temp, $item, comma);
+  $intersection: ();
+
+  @each $item in $unique {
+    $exists: true;
+
+    @each $other in $others {
+      @if not index($other, $item) {
+        $exists: false;
       }
     }
 
-    $filtered: $temp;
+    @if $exists {
+      $intersection: append($intersection, $item, comma);
+    }
   }
 
-  @return $filtered;
+  @return $intersection;
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "grunt-contrib-sass": "~0.5.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-init": "~0.2.1",
-    "bootcamp": "~0.0.5"
+    "bootcamp": "~1.0.0"
   },
   "peerDependencies": {},
   "engines": {

--- a/test/lists/first.scss
+++ b/test/lists/first.scss
@@ -4,17 +4,17 @@
     $strings:  "foo", "bar", "baz";
     $booleans: true, false, false;
 
-    @include should(expect( first($numbers ) ), to( equal( 1 )));
-    @include should(expect( first($strings ) ), to( equal( "foo" )));
-    @include should(expect( first($booleans) ), to( equal( true )));
+    @include should(expect( first($numbers ) ), to( be( 1 )));
+    @include should(expect( first($strings ) ), to( be( "foo" )));
+    @include should(expect( first($booleans) ), to( be( true )));
 
-    @include should(expect( head($numbers ) ), to( equal( 1 )));
-    @include should(expect( head($strings ) ), to( equal( "foo" )));
-    @include should(expect( head($booleans) ), to( equal( true )));
+    @include should(expect( head($numbers ) ), to( be( 1 )));
+    @include should(expect( head($strings ) ), to( be( "foo" )));
+    @include should(expect( head($booleans) ), to( be( true )));
 
-    @include should(expect( take($numbers ) ), to( equal( 1 )));
-    @include should(expect( take($strings ) ), to( equal( "foo" )));
-    @include should(expect( take($booleans) ), to( equal( true )));
+    @include should(expect( take($numbers ) ), to( be( 1 )));
+    @include should(expect( take($strings ) ), to( be( "foo" )));
+    @include should(expect( take($booleans) ), to( be( true )));
   }
 
   @include it("should return the first nth items in an array") {
@@ -22,17 +22,17 @@
     $strings:  "foo", "bar", "baz";
     $booleans: true, false, false;
 
-    @include should(expect( first($numbers , 2) ), to( equal( (1, 2) )));
-    @include should(expect( first($strings , 2) ), to( equal( ("foo", "bar") )));
-    @include should(expect( first($booleans, 2) ), to( equal( (true, false) )));
+    @include should(expect( first($numbers , 2) ), to( be( (1, 2) )));
+    @include should(expect( first($strings , 2) ), to( be( ("foo", "bar") )));
+    @include should(expect( first($booleans, 2) ), to( be( (true, false) )));
 
-    @include should(expect( head($numbers , 2) ), to( equal( (1, 2) )));
-    @include should(expect( head($strings , 2) ), to( equal( ("foo", "bar") )));
-    @include should(expect( head($booleans, 2) ), to( equal( (true, false) )));
+    @include should(expect( head($numbers , 2) ), to( be( (1, 2) )));
+    @include should(expect( head($strings , 2) ), to( be( ("foo", "bar") )));
+    @include should(expect( head($booleans, 2) ), to( be( (true, false) )));
 
-    @include should(expect( take($numbers , 2) ), to( equal( (1, 2) )));
-    @include should(expect( take($strings , 2) ), to( equal( ("foo", "bar") )));
-    @include should(expect( take($booleans, 2) ), to( equal( (true, false) )));
+    @include should(expect( take($numbers , 2) ), to( be( (1, 2) )));
+    @include should(expect( take($strings , 2) ), to( be( ("foo", "bar") )));
+    @include should(expect( take($booleans, 2) ), to( be( (true, false) )));
   }
 
   @include it("should return the only item in an single item array") {
@@ -40,17 +40,17 @@
     $string: "foo";
     $boolean: true;
 
-    @include should(expect( first($number ) ), to( equal( 1 )));
-    @include should(expect( first($string ) ), to( equal( "foo" )));
-    @include should(expect( first($boolean) ), to( equal( true )));
+    @include should(expect( first($number ) ), to( be( 1 )));
+    @include should(expect( first($string ) ), to( be( "foo" )));
+    @include should(expect( first($boolean) ), to( be( true )));
 
-    @include should(expect( head($number ) ), to( equal( 1 )));
-    @include should(expect( head($string ) ), to( equal( "foo" )));
-    @include should(expect( head($boolean) ), to( equal( true )));
+    @include should(expect( head($number ) ), to( be( 1 )));
+    @include should(expect( head($string ) ), to( be( "foo" )));
+    @include should(expect( head($boolean) ), to( be( true )));
 
-    @include should(expect( take($number ) ), to( equal( 1 )));
-    @include should(expect( take($string ) ), to( equal( "foo" )));
-    @include should(expect( take($boolean) ), to( equal( true )));
+    @include should(expect( take($number ) ), to( be( 1 )));
+    @include should(expect( take($string ) ), to( be( "foo" )));
+    @include should(expect( take($boolean) ), to( be( true )));
   }
 
   @include it("should return null when a list is empty") {

--- a/test/lists/initial.scss
+++ b/test/lists/initial.scss
@@ -4,9 +4,9 @@
     $strings:  "foo", "bar", "baz";
     $booleans: true, false, false;
 
-    @include should(expect( initial($numbers ) ), to( equal( (1, 2) )));
-    @include should(expect( initial($strings ) ), to( equal( ("foo", "bar") )));
-    @include should(expect( initial($booleans) ), to( equal( (true, false) )));
+    @include should(expect( initial($numbers ) ), to( be( (1, 2) )));
+    @include should(expect( initial($strings ) ), to( be( ("foo", "bar") )));
+    @include should(expect( initial($booleans) ), to( be( (true, false) )));
   }
 
   @include it("should return the initial nth items in an array") {
@@ -14,9 +14,9 @@
     $strings:  "foo", "bar", "baz";
     $booleans: true, false, false;
 
-    @include should(expect( initial($numbers , 2) ), to( equal( 1 )));
-    @include should(expect( initial($strings , 2) ), to( equal( "foo" )));
-    @include should(expect( initial($booleans, 2) ), to( equal( true )));
+    @include should(expect( initial($numbers , 2) ), to( be( 1 )));
+    @include should(expect( initial($strings , 2) ), to( be( "foo" )));
+    @include should(expect( initial($booleans, 2) ), to( be( true )));
   }
 
   @include it("should return the only item in an single item array") {
@@ -24,9 +24,9 @@
     $string: "foo";
     $boolean: true;
 
-    @include should(expect( initial($number ) ), to( equal( 1 )));
-    @include should(expect( initial($string ) ), to( equal( "foo" )));
-    @include should(expect( initial($boolean) ), to( equal( true )));
+    @include should(expect( initial($number ) ), to( be( 1 )));
+    @include should(expect( initial($string ) ), to( be( "foo" )));
+    @include should(expect( initial($boolean) ), to( be( true )));
   }
 
   @include it("should return null when a list is empty") {

--- a/test/lists/intersection.scss
+++ b/test/lists/intersection.scss
@@ -17,10 +17,20 @@
     @include should(expect( intersection($list-3a, $list-3b, $list-3c) ), to( be( ( true, false ) )));
   }
 
+  @include it("should only return unique values") {
+    $list-1: 1, 1, 1;
+    $list-2: "foo", "foo", "foo";
+    $list-3: true, true, true;
+
+    @include should(expect( intersection($list-1, $list-1, $list-1) ), to( be( 1 )));
+    @include should(expect( intersection($list-2, $list-2, $list-2) ), to( be( "foo" )));
+    @include should(expect( intersection($list-3, $list-3, $list-3) ), to( be( true )));
+  }
+
   @include it("should return one item if all the items are the same") {
-    @include should(expect( intersection(1, 1, 1)             ), to( be( ( 1     ) )));
-    @include should(expect( intersection("foo", "foo", "foo") ), to( be( ( "foo" ) )));
-    @include should(expect( intersection(false, false, false) ), to( be( ( false ) )));
+    @include should(expect( intersection(1, 1, 1)             ), to( be( 1 )));
+    @include should(expect( intersection("foo", "foo", "foo") ), to( be( "foo" )));
+    @include should(expect( intersection(false, false, false) ), to( be( false )));
   }
 
   @include it("should return nothing if all the items are the same except one") {

--- a/test/lists/intersection.scss
+++ b/test/lists/intersection.scss
@@ -12,15 +12,15 @@
     $list-3b: true,   null, false;
     $list-3c: null,  false,  true;
 
-    @include should(expect( intersection($list-1a, $list-1b, $list-1c) ), to( equal( ( 1, 2 ) )));
-    @include should(expect( intersection($list-2a, $list-2b, $list-2c) ), to( equal( ( "foo", "bar" ) )));
-    @include should(expect( intersection($list-3a, $list-3b, $list-3c) ), to( equal( ( true, false ) )));
+    @include should(expect( intersection($list-1a, $list-1b, $list-1c) ), to( be( ( 1, 2 ) )));
+    @include should(expect( intersection($list-2a, $list-2b, $list-2c) ), to( be( ( "foo", "bar" ) )));
+    @include should(expect( intersection($list-3a, $list-3b, $list-3c) ), to( be( ( true, false ) )));
   }
 
   @include it("should return one item if all the items are the same") {
-    @include should(expect( intersection(1, 1, 1)             ), to( equal( ( 1     ) )));
-    @include should(expect( intersection("foo", "foo", "foo") ), to( equal( ( "foo" ) )));
-    @include should(expect( intersection(false, false, false) ), to( equal( ( false ) )));
+    @include should(expect( intersection(1, 1, 1)             ), to( be( ( 1     ) )));
+    @include should(expect( intersection("foo", "foo", "foo") ), to( be( ( "foo" ) )));
+    @include should(expect( intersection(false, false, false) ), to( be( ( false ) )));
   }
 
   @include it("should return nothing if all the items are the same except one") {

--- a/test/lists/last.scss
+++ b/test/lists/last.scss
@@ -4,9 +4,9 @@
     $strings:  "foo", "bar", "baz";
     $booleans: true, false, false;
 
-    @include should(expect( last($numbers ) ), to( equal( (3) )));
-    @include should(expect( last($strings ) ), to( equal( ("baz") )));
-    @include should(expect( last($booleans) ), to( equal( (false) )));
+    @include should(expect( last($numbers ) ), to( be( (3) )));
+    @include should(expect( last($strings ) ), to( be( ("baz") )));
+    @include should(expect( last($booleans) ), to( be( (false) )));
   }
 
   @include it("should return the last nth items in an array") {
@@ -14,9 +14,9 @@
     $strings:  "foo", "bar", "baz";
     $booleans: true, false, false;
 
-    @include should(expect( last($numbers , 1) ), to( equal( 3 )));
-    @include should(expect( last($strings , 1) ), to( equal( "baz" )));
-    @include should(expect( last($booleans, 1) ), to( equal( false )));
+    @include should(expect( last($numbers , 1) ), to( be( 3 )));
+    @include should(expect( last($strings , 1) ), to( be( "baz" )));
+    @include should(expect( last($booleans, 1) ), to( be( false )));
   }
 
   @include it("should return the only item in an single item array") {
@@ -24,9 +24,9 @@
     $string: "foo";
     $boolean: true;
 
-    @include should(expect( last($number ) ), to( equal( 1 )));
-    @include should(expect( last($string ) ), to( equal( "foo" )));
-    @include should(expect( last($boolean) ), to( equal( true )));
+    @include should(expect( last($number ) ), to( be( 1 )));
+    @include should(expect( last($string ) ), to( be( "foo" )));
+    @include should(expect( last($boolean) ), to( be( true )));
   }
 
   @include it("should return null when a list is empty") {

--- a/test/lists/rest.scss
+++ b/test/lists/rest.scss
@@ -4,17 +4,17 @@
     $strings:  "foo", "bar", "baz";
     $booleans: true, false, false;
 
-    @include should(expect( rest($numbers ) ), to( equal( (2, 3) )));
-    @include should(expect( rest($strings ) ), to( equal( ("bar", "baz") )));
-    @include should(expect( rest($booleans) ), to( equal( (false, false) )));
+    @include should(expect( rest($numbers ) ), to( be( (2, 3) )));
+    @include should(expect( rest($strings ) ), to( be( ("bar", "baz") )));
+    @include should(expect( rest($booleans) ), to( be( (false, false) )));
 
-    @include should(expect( tail($numbers ) ), to( equal( (2, 3) )));
-    @include should(expect( tail($strings ) ), to( equal( ("bar", "baz") )));
-    @include should(expect( tail($booleans) ), to( equal( (false, false) )));
+    @include should(expect( tail($numbers ) ), to( be( (2, 3) )));
+    @include should(expect( tail($strings ) ), to( be( ("bar", "baz") )));
+    @include should(expect( tail($booleans) ), to( be( (false, false) )));
 
-    @include should(expect( drop($numbers ) ), to( equal( (2, 3) )));
-    @include should(expect( drop($strings ) ), to( equal( ("bar", "baz") )));
-    @include should(expect( drop($booleans) ), to( equal( (false, false) )));
+    @include should(expect( drop($numbers ) ), to( be( (2, 3) )));
+    @include should(expect( drop($strings ) ), to( be( ("bar", "baz") )));
+    @include should(expect( drop($booleans) ), to( be( (false, false) )));
   }
 
   @include it("should return the rest nth items in an array") {
@@ -22,17 +22,17 @@
     $strings:  "foo", "bar", "baz";
     $booleans: true, false, false;
 
-    @include should(expect( rest($numbers , 2) ), to( equal( 3 )));
-    @include should(expect( rest($strings , 2) ), to( equal( "baz" )));
-    @include should(expect( rest($booleans, 2) ), to( equal( false )));
+    @include should(expect( rest($numbers , 2) ), to( be( 3 )));
+    @include should(expect( rest($strings , 2) ), to( be( "baz" )));
+    @include should(expect( rest($booleans, 2) ), to( be( false )));
 
-    @include should(expect( tail($numbers , 2) ), to( equal( 3 )));
-    @include should(expect( tail($strings , 2) ), to( equal( "baz" )));
-    @include should(expect( tail($booleans, 2) ), to( equal( false )));
+    @include should(expect( tail($numbers , 2) ), to( be( 3 )));
+    @include should(expect( tail($strings , 2) ), to( be( "baz" )));
+    @include should(expect( tail($booleans, 2) ), to( be( false )));
 
-    @include should(expect( drop($numbers , 2) ), to( equal( 3 )));
-    @include should(expect( drop($strings , 2) ), to( equal( "baz" )));
-    @include should(expect( drop($booleans, 2) ), to( equal( false )));
+    @include should(expect( drop($numbers , 2) ), to( be( 3 )));
+    @include should(expect( drop($strings , 2) ), to( be( "baz" )));
+    @include should(expect( drop($booleans, 2) ), to( be( false )));
   }
 
   @include it("should return the only item in an single item array") {
@@ -40,17 +40,17 @@
     $string: "foo";
     $boolean: true;
 
-    @include should(expect( rest($number ) ), to( equal( 1 )));
-    @include should(expect( rest($string ) ), to( equal( "foo" )));
-    @include should(expect( rest($boolean) ), to( equal( true )));
+    @include should(expect( rest($number ) ), to( be( 1 )));
+    @include should(expect( rest($string ) ), to( be( "foo" )));
+    @include should(expect( rest($boolean) ), to( be( true )));
 
-    @include should(expect( tail($number ) ), to( equal( 1 )));
-    @include should(expect( tail($string ) ), to( equal( "foo" )));
-    @include should(expect( tail($boolean) ), to( equal( true )));
+    @include should(expect( tail($number ) ), to( be( 1 )));
+    @include should(expect( tail($string ) ), to( be( "foo" )));
+    @include should(expect( tail($boolean) ), to( be( true )));
 
-    @include should(expect( drop($number ) ), to( equal( 1 )));
-    @include should(expect( drop($string ) ), to( equal( "foo" )));
-    @include should(expect( drop($boolean) ), to( equal( true )));
+    @include should(expect( drop($number ) ), to( be( 1 )));
+    @include should(expect( drop($string ) ), to( be( "foo" )));
+    @include should(expect( drop($boolean) ), to( be( true )));
   }
 
   @include it("should return null when a list is empty") {

--- a/test/lists/union.scss
+++ b/test/lists/union.scss
@@ -12,15 +12,15 @@
     $list-3b: true,  null, false;
     $list-3c: null,  null,  true;
 
-    @include should(expect( union($list-1a, $list-1b, $list-1c) ), to( equal( ( 1, 2, 3, 4, 6, 8  ) )));
-    @include should(expect( union($list-2a, $list-2b, $list-2c) ), to( equal( ( "foo", "bar", "baz", "nan" ) )));
-    @include should(expect( union($list-3a, $list-3b, $list-3c) ), to( equal( ( true, false, null ) )));
+    @include should(expect( union($list-1a, $list-1b, $list-1c) ), to( be( ( 1, 2, 3, 4, 6, 8  ) )));
+    @include should(expect( union($list-2a, $list-2b, $list-2c) ), to( be( ( "foo", "bar", "baz", "nan" ) )));
+    @include should(expect( union($list-3a, $list-3b, $list-3c) ), to( be( ( true, false, null ) )));
   }
 
   @include it("should return one item if all the items are the same") {
-    @include should(expect( union(1, 1, 1) ), to( equal( ( 1 ) )));
-    @include should(expect( union("foo", "foo", "foo") ), to( equal( ( "foo" ) )));
-    @include should(expect( union(false, false, false) ), to( equal( ( false ) )));
+    @include should(expect( union(1, 1, 1) ), to( be( ( 1 ) )));
+    @include should(expect( union("foo", "foo", "foo") ), to( be( ( "foo" ) )));
+    @include should(expect( union(false, false, false) ), to( be( ( false ) )));
   }
 
   @include it("should only go one level deep") {
@@ -36,9 +36,9 @@
     $list-3b: true, ( null, false);
     $list-3c: null, ( null,  true);
 
-    @include should(expect( union($list-1a, $list-1b, $list-1c) ), not-to( equal( ( 1, 2, 3, 4, 6, 8 ) )));
-    @include should(expect( union($list-2a, $list-2b, $list-2c) ), not-to( equal( ( "foo", "bar", "baz", "nan" ) )));
-    @include should(expect( union($list-3a, $list-3b, $list-3c) ), not-to( equal( ( true, false, null ) )));
+    @include should(expect( union($list-1a, $list-1b, $list-1c) ), not-to( be( ( 1, 2, 3, 4, 6, 8 ) )));
+    @include should(expect( union($list-2a, $list-2b, $list-2c) ), not-to( be( ( "foo", "bar", "baz", "nan" ) )));
+    @include should(expect( union($list-3a, $list-3b, $list-3c) ), not-to( be( ( true, false, null ) )));
   }
 
   @include it("should leave an empty array alone") {

--- a/test/lists/without.scss
+++ b/test/lists/without.scss
@@ -5,11 +5,11 @@
     $list-3: true, false, true, true, false;
     $list-4: null, false, null, null;
 
-    @include should(expect( without($list-1, 1, 3, 6)   ), to( equal( (2, 4, 5)          )));
-    @include should(expect( without($list-2, "b", "x")  ), to( equal( ("a", "c")         )));
-    @include should(expect( without($list-3, true)      ), to( equal( (false, false)     )));
-    @include should(expect( without($list-3, false)     ), to( equal( (true, true, true) )));
-    @include should(expect( without($list-4, false) ), to( equal( (null, null, null) )));
+    @include should(expect( without($list-1, 1, 3, 6)   ), to( be( (2, 4, 5)          )));
+    @include should(expect( without($list-2, "b", "x")  ), to( be( ("a", "c")         )));
+    @include should(expect( without($list-3, true)      ), to( be( (false, false)     )));
+    @include should(expect( without($list-3, false)     ), to( be( (true, true, true) )));
+    @include should(expect( without($list-4, false)     ), to( be( (null, null, null) )));
   }
 
   @include it("should return same list when no equaling values") {
@@ -18,15 +18,15 @@
     $list-3: true, false, true, true, false;
     $list-4: null, false, null, null;
 
-    @include should(expect( without($list-1, green) ), to( equal( $list-1 )));
-    @include should(expect( without($list-2, green) ), to( equal( $list-2 )));
-    @include should(expect( without($list-3, green) ), to( equal( $list-3 )));
-    @include should(expect( without($list-4, green) ), to( equal( $list-4 )));
+    @include should(expect( without($list-1, green) ), to( be( $list-1 )));
+    @include should(expect( without($list-2, green) ), to( be( $list-2 )));
+    @include should(expect( without($list-3, green) ), to( be( $list-3 )));
+    @include should(expect( without($list-4, green) ), to( be( $list-4 )));
   }
 
   @include it("should leave empty lists alone") {
     $list: ();
 
-    @include should(expect( without($list, green) ), to( equal( $list )));
+    @include should(expect( without($list, green) ), to( be( $list )));
   }
 }


### PR DESCRIPTION
`0.0.5 => 1.0`

Requires replacing `equal` matcher with `be` matcher
